### PR TITLE
回答生成に並行処理を導入

### DIFF
--- a/app/internal/handler/llm_generate_handler.go
+++ b/app/internal/handler/llm_generate_handler.go
@@ -45,7 +45,7 @@ func (h *llmGenerateHandler) Generate(c echo.Context) error {
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
-			"error": "LLM生成に失敗しました",
+			"error": err.Error(),	
 		})
 	}
 

--- a/app/internal/handler/llm_generate_handler.go
+++ b/app/internal/handler/llm_generate_handler.go
@@ -45,7 +45,7 @@ func (h *llmGenerateHandler) Generate(c echo.Context) error {
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
-			"error": err.Error(),	
+			"error": err.Error(),
 		})
 	}
 

--- a/app/internal/usecase/llm_generate_usecase.go
+++ b/app/internal/usecase/llm_generate_usecase.go
@@ -144,9 +144,6 @@ func (u *llmGenerateUsecase) LLMGenerate(c echo.Context, req model.LLMGenerateRe
 	}()
 
 	answers := make([]model.LLMGeneratedResponse, len(questions))
-	for i := range answers {
-		answers[i] = model.LLMGeneratedResponse{}
-	}
 	validAnswers := 0
 
 	for resp := range responseCh {

--- a/app/internal/usecase/llm_generate_usecase.go
+++ b/app/internal/usecase/llm_generate_usecase.go
@@ -87,6 +87,13 @@ func (u *llmGenerateUsecase) LLMGenerate(c echo.Context, req model.LLMGenerateRe
 	for i, question := range questions {
 		wg.Add(1)
 		go func(idx int, q string) {
+			defer func() {
+				if r := recover(); r != nil {
+					errorCh <- fmt.Errorf("質問「%s」の処理中にパニックが発生: %v", q, r)
+					wg.Done()
+				}
+			}()
+
 			defer wg.Done()
 
 			type apiResponse struct {

--- a/app/internal/usecase/llm_generate_usecase.go
+++ b/app/internal/usecase/llm_generate_usecase.go
@@ -131,15 +131,8 @@ func (u *llmGenerateUsecase) LLMGenerate(c echo.Context, req model.LLMGenerateRe
 	}
 
 	if validAnswers != len(questions) {
-		var firstError error
-		for err := range errorCh {
-			if firstError == nil {
-				firstError = err
-			}
-		}
-
-		if firstError != nil {
-			return nil, firstError
+		if err, ok := <-errorCh; ok {
+			return nil, err
 		}
 		return nil, fmt.Errorf("回答を生成できませんでした")
 	}


### PR DESCRIPTION
## 概要
- 並行処理を導入
<!-- Jiraのチケット、Issuesなどあれば記載 -->
<!-- PRの概要と実施背景を記載 -->

## 変更点
- 回答生成を並行で行うようにしました
<!-- コードの変更点を明記 -->
<!-- 必要に応じてスクリーンショットやドキュメントなどのリンクを貼る -->

## 影響範囲・懸念点
```
		return nil, fmt.Errorf("回答を生成できませんでした")
```
この行に入ることは基本的には無いはず（質問の数に回答が足りないのに、何らかの通信の際にエラーが潰されてしまった場合など？）だけど、安全性のために一応エラーハンドリングとして入ってます
<!-- 影響が及びそうな範囲、レビューしてほしい点を記載 -->
- 毎回buildprompt呼び出してるから経歴と企業情報は作るの一回にして、その後に質問だけ各チャネルで付け加えてもいいかも？
- 正直そんなに詳しく試してないから、どこがそんなにボトルネックなのかがわかってない
## 動作確認
- したけど、10秒くらい掛かってて萎え
<!-- 実施した動作確認 -->
<!-- レビュイーのために実際のコマンドなどあると◯ -->

## その他
#22 