### PR TITLE
キャッシュ機能の追加

### DIFF
--- a/app/cmd/server/main.go
+++ b/app/cmd/server/main.go
@@ -24,6 +24,7 @@ func main() {
 	}
 	dbConnManager := db.NewDBConnectionManager()
 	experienceRepository := dbRepo.NewExperienceRepositoryWithDBManager(dbConnManager)
+	companyResearchRepository := dbRepo.NewCompanyResearchRepositoryWithDBManager(dbConnManager)
 	clerkAuthRepository := clerkRepo.NewClerkAuthRepository()
 	geminiRepository := geminiRepo.NewGeminiRepository()
 	tavilyRepository := tavilyRepo.NewTavilyRepository()
@@ -34,6 +35,7 @@ func main() {
 		geminiRepository,
 		tavilyRepository,
 		experienceRepository,
+		companyResearchRepository,
 	)
 	experienceHandler := handler.NewExperienceHandler(experienceUsecase)
 	llmGenerateHandler := handler.NewLLMGenerateHandler(llmGenerateUsecase)

--- a/app/infrastructure/migrate/migrate.go
+++ b/app/infrastructure/migrate/migrate.go
@@ -17,5 +17,9 @@ func RunMigrations(db *gorm.DB) {
 	if err != nil {
 		log.Fatalf("🔴 Error migrating Experience model: %s", err)
 	}
-	log.Println("🟢 User and Experience models migrated")
+	err = db.AutoMigrate(&model.CompanyResearch{})
+	if err != nil {
+		log.Fatalf("🔴 Error migrating CompanyResearch model: %s", err)
+	}
+	log.Println("🟢 Migrations completed")
 }

--- a/app/internal/entity/model/company.go
+++ b/app/internal/entity/model/company.go
@@ -4,14 +4,14 @@ import "time"
 
 // CompanyResearch - 企業情報のキャッシュ用モデル
 type CompanyResearch struct {
-	ID          uint      `gorm:"primaryKey;autoIncrement" json:"id"`
-	CompanyID   string    `gorm:"unique;not null" json:"company_id"` // gBizINFOの法人番号
-	CompanyName string    `gorm:"not null" json:"company_name"`      // 企業名
-	Philosophy  string    `gorm:"not null" json:"philosophy"`        // 企業理念
-	CareerPath  string    `gorm:"not null" json:"career_path"`       // キャリアパス
-	TalentNeeds string    `gorm:"not null" json:"talent_needs"`      // 求める人材像
-	CreatedAt   time.Time `gorm:"not null" json:"created_at"`
-	UpdatedAt   time.Time `gorm:"not null" json:"updated_at"`
+	ID          uint      `json:"id" gorm:"primaryKey;autoIncrement"`
+	CompanyID   string    `json:"company_id" gorm:"unique;not null"` // gBizINFOの法人番号
+	CompanyName string    `json:"company_name" gorm:"not null"`      // 企業名
+	Philosophy  string    `json:"philosophy" gorm:"not null"`        // 企業理念
+	CareerPath  string    `json:"career_path" gorm:"not null"`       // キャリアパス
+	TalentNeeds string    `json:"talent_needs" gorm:"not null"`      // 求める人材像
+	CreatedAt   time.Time `json:"created_at" gorm:"not null"`
+	UpdatedAt   time.Time `json:"updated_at" gorm:"not null"`
 }
 
 // CompanyBasicInfo - 企業検索結果用の基本情報

--- a/app/internal/entity/model/company.go
+++ b/app/internal/entity/model/company.go
@@ -4,14 +4,14 @@ import "time"
 
 // CompanyResearch - 企業情報のキャッシュ用モデル
 type CompanyResearch struct {
-	ID          uint      `gorm:"primaryKey" json:"id"`
-	CompanyID   string    `json:"company_id"`   // gBizINFOの法人番号
-	CompanyName string    `json:"company_name"` // 企業名
-	Philosophy  string    `json:"philosophy"`   // 企業理念
-	CareerPath  string    `json:"career_path"`  // キャリアパス
-	TalentNeeds string    `json:"talent_needs"` // 求める人材像
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID          uint      `gorm:"primaryKey;autoIncrement" json:"id"`
+	CompanyID   string    `gorm:"unique;not null" json:"company_id"` // gBizINFOの法人番号
+	CompanyName string    `gorm:"not null" json:"company_name"`      // 企業名
+	Philosophy  string    `gorm:"not null" json:"philosophy"`        // 企業理念
+	CareerPath  string    `gorm:"not null" json:"career_path"`       // キャリアパス
+	TalentNeeds string    `gorm:"not null" json:"talent_needs"`      // 求める人材像
+	CreatedAt   time.Time `gorm:"not null" json:"created_at"`
+	UpdatedAt   time.Time `gorm:"not null" json:"updated_at"`
 }
 
 // CompanyBasicInfo - 企業検索結果用の基本情報

--- a/app/internal/entity/model/llmgenerate.go
+++ b/app/internal/entity/model/llmgenerate.go
@@ -6,8 +6,9 @@ type LLMGeneratedResponse struct {
 }
 
 type LLMGenerateRequest struct {
-	Questions []string `json:"questions"`
-	Company   string   `json:"company"`
-	HTML      string   `json:"html"`
-	Model     string   `json:"model"`
+	Questions   []string `json:"questions"`
+	CompanyName string   `json:"companyName"`
+	CompanyID   string   `json:"companyId"`
+	HTML        string   `json:"html"`
+	Model       string   `json:"model"`
 }

--- a/app/internal/handler/llm_generate_handler.go
+++ b/app/internal/handler/llm_generate_handler.go
@@ -34,8 +34,8 @@ func (h *llmGenerateHandler) Generate(c echo.Context) error {
 		})
 	}
 
-	if req.Company == "" || req.HTML == "" {
-		log.Printf("必須パラメータ不足: company=%v, html=%v", req.Company != "", req.HTML != "")
+	if req.CompanyName == "" || req.CompanyID == "" || req.HTML == "" {
+		log.Printf("必須パラメータ不足: companyName=%v, companyID=%v, html=%v", req.CompanyName != "", req.CompanyID != "", req.HTML != "")
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "必要なパラメータが不足しています",
 		})

--- a/app/internal/repository/db/company_research_repository.go
+++ b/app/internal/repository/db/company_research_repository.go
@@ -1,0 +1,65 @@
+package repository
+
+import (
+	"es-api/app/infrastructure/db"
+	"es-api/app/internal/entity/model"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+type CompanyResearchRepository interface {
+	FindByCompanyID(c echo.Context, companyID string) (*model.CompanyResearch, error)
+	Create(c echo.Context, research *model.CompanyResearch) error
+}
+
+type companyResearchRepository struct {
+	dbManager db.DBConnectionManager
+	defaultDB *gorm.DB
+}
+
+func NewCompanyResearchRepository(defaultDB *gorm.DB) CompanyResearchRepository {
+	return &companyResearchRepository{
+		defaultDB: defaultDB,
+	}
+}
+
+func NewCompanyResearchRepositoryWithDBManager(dbManager db.DBConnectionManager) CompanyResearchRepository {
+	return &companyResearchRepository{
+		dbManager: dbManager,
+		defaultDB: dbManager.GetConnection("clerk"),
+	}
+}
+
+// FindByCompanyID - 法人番号で企業情報を検索
+func (r *companyResearchRepository) FindByCompanyID(c echo.Context, companyID string) (*model.CompanyResearch, error) {
+	idp := c.Request().Header.Get("idp")
+	var dbConn *gorm.DB
+	if r.dbManager != nil && idp != "" {
+		dbConn = r.dbManager.GetConnection(idp)
+	} else {
+		dbConn = r.defaultDB
+	}
+
+	var research model.CompanyResearch
+	result := dbConn.Where("company_id = ?", companyID).Find(&research)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return nil, nil
+	}
+	return &research, nil
+}
+
+// Create - 企業情報を新規作成
+func (r *companyResearchRepository) Create(c echo.Context, research *model.CompanyResearch) error {
+	idp := c.Request().Header.Get("idp")
+	var dbConn *gorm.DB
+	if r.dbManager != nil && idp != "" {
+		dbConn = r.dbManager.GetConnection(idp)
+	} else {
+		dbConn = r.defaultDB
+	}
+	return dbConn.Create(research).Error
+}

--- a/app/internal/repository/db/company_research_repository_test.go
+++ b/app/internal/repository/db/company_research_repository_test.go
@@ -1,0 +1,64 @@
+package repository_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"es-api/app/internal/entity/model"
+	repository "es-api/app/internal/repository/db"
+	"es-api/app/test"
+	"es-api/app/test/factory"
+)
+
+func TestCompanyResearchRepository_FindByCompanyID(t *testing.T) {
+	db := test.SetupTestDB(t, "../../../../.env")
+	defer test.CleanupDB(t, db)
+
+	repo := repository.NewCompanyResearchRepository(db)
+
+	t.Run("異常系:企業情報が存在しない場合", func(t *testing.T) {
+		ctx := test.SetupEchoContext("")
+		research, err := repo.FindByCompanyID(ctx, "non-existent-id")
+
+		assert.NoError(t, err)
+		assert.Nil(t, research)
+	})
+
+	t.Run("正常系:企業情報が存在する場合", func(t *testing.T) {
+		dummyResearch := factory.CreateCompanyResearch(t, db)
+
+		ctx := test.SetupEchoContext("")
+		research, err := repo.FindByCompanyID(ctx, dummyResearch.CompanyID)
+		assert.NoError(t, err)
+		assert.NotNil(t, research)
+		assert.Equal(t, dummyResearch.CompanyID, research.CompanyID)
+		assert.Equal(t, dummyResearch.CompanyName, research.CompanyName)
+		assert.Equal(t, dummyResearch.Philosophy, research.Philosophy)
+		assert.Equal(t, dummyResearch.CareerPath, research.CareerPath)
+		assert.Equal(t, dummyResearch.TalentNeeds, research.TalentNeeds)
+	})
+}
+
+func TestCompanyResearchRepository_Create(t *testing.T) {
+	db := test.SetupTestDB(t, "../../../../.env")
+	defer test.CleanupDB(t, db)
+
+	repo := repository.NewCompanyResearchRepository(db)
+
+	t.Run("正常系:新規企業情報の作成", func(t *testing.T) {
+		newResearch := &model.CompanyResearch{
+			CompanyID:   "9999999999999",
+			CompanyName: "テスト株式会社2",
+			Philosophy:  "テスト企業理念2",
+			CareerPath:  "テストキャリアパス2",
+			TalentNeeds: "テスト求める人材像2",
+		}
+
+		ctx := test.SetupEchoContext("")
+		err := repo.Create(ctx, newResearch)
+
+		assert.NoError(t, err)
+		assert.NotZero(t, newResearch.ID)
+	})
+}

--- a/app/test/factory/company_research.go
+++ b/app/test/factory/company_research.go
@@ -1,0 +1,26 @@
+package factory
+
+import (
+	"testing"
+
+	"es-api/app/internal/entity/model"
+
+	"gorm.io/gorm"
+)
+
+func CreateCompanyResearch(t *testing.T, db *gorm.DB) *model.CompanyResearch {
+	research := &model.CompanyResearch{
+		CompanyID:   "1234567890123",
+		CompanyName: "テスト株式会社",
+		Philosophy:  "テスト企業理念",
+		CareerPath:  "テストキャリアパス",
+		TalentNeeds: "テスト求める人材像",
+	}
+
+	err := db.Create(research).Error
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return research
+}

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -218,10 +218,14 @@ components:
     InputGenerateSchema:
       type: object
       properties:
-        company:
+        companyName:
           type: string
           description: Company name
-          example: 株式会社DeNA
+          example: 株式会社ディー・エヌ・エー
+        companyId:
+          type: string
+          description: Company legal number
+          example: "4011001032721"
         model:
           type: string
           description: LLM model


### PR DESCRIPTION
## 概要

- close #19 

## 変更点

- 生成リクエストが飛んできたときに、キャッシュを確認してあったらそれを、なかったらtavilyに問い合わせた結果をキャッシュする処理を追加

## 影響範囲・懸念点

- /api/generateのbodyが変わってます

## 動作確認

- swaggerとテストで確認済み

## その他

- #26 と同時並行でやってたせいでお互いに余計なor足りない変更があるかも。あったらゴメン
