### PR TITLE
fix: 企業基本情報のJSONフィールド名を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
         DB_PORT=${{ secrets.DB_PORT }}
         CLERK_JWKS_URL=${{ secrets.CLERK_JWKS_URL }}
         GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
+        GBIZ_API_KEY=${{ secrets.GBIZ_API_KEY }}
         EOF
 
     - name: Build

--- a/app/infrastructure/db/db.go
+++ b/app/infrastructure/db/db.go
@@ -121,4 +121,6 @@ func NewTestDB() *gorm.DB {
 
 func CleanupTestDB(db *gorm.DB) {
 	db.Exec("DELETE FROM users")
+	db.Exec("DELETE FROM experiences")
+	db.Exec("DELETE FROM company_researches")
 }

--- a/app/internal/entity/model/company.go
+++ b/app/internal/entity/model/company.go
@@ -16,8 +16,8 @@ type CompanyResearch struct {
 
 // CompanyBasicInfo - 企業検索結果用の基本情報
 type CompanyBasicInfo struct {
-	CompanyID   string `json:"corporate_number"` // 法人番号
-	CompanyName string `json:"name"`             // 企業名
+	CompanyID   string `json:"companyId"`
+	CompanyName string `json:"companyName"`
 }
 
 // GBizInfoResponse - gBizINFO APIのレスポンス

--- a/schema/openapi.yml
+++ b/schema/openapi.yml
@@ -284,11 +284,11 @@ components:
     CompanyBasicInfo:
       type: object
       properties:
-        corporate_number:
+        companyId:
           type: string
           description: Company legal number
           example: "1234567890123"
-        name:
+        companyName:
           type: string
           description: Company name
           example: 株式会社テスト


### PR DESCRIPTION
## 概要

- close #30 

## 変更点

/api/companies/searchのレスポンスを
```
[
  {
    "corporate_number": "1234567890123",
    "name": "株式会社テスト"
  }
]
```
から
```
[
  {
    "companyId": "1234567890123",
    "companyName": "株式会社テスト"
  }
]
```
に変更

## 影響範囲・懸念点

- まあ普通にAPIの戻り方が変わります

## 動作確認

- swaggerで

## その他

- `gbiz_repository.go`ではCorporateNumberはそのままです。usecaseにより上ではCompanyIDに詰め替えてます。（gzibのjsonのフィールド名がcorporate_numberだから）