### PR TITLE
contextをフレームワーク非依存にする

### DIFF
--- a/app/internal/contextKey/ctxKey.go
+++ b/app/internal/contextKey/ctxKey.go
@@ -1,10 +1,13 @@
 package contextKey
 
-type userIDKey struct {}
+type userIDKey struct{}
+
 var UserIDKey = userIDKey{}
 
-type idpKey struct {}
+type idpKey struct{}
+
 var IDPKey = idpKey{}
 
-type keywordKey struct {}
+type keywordKey struct{}
+
 var KeywordKey = keywordKey{}

--- a/app/internal/contextKey/ctxKey.go
+++ b/app/internal/contextKey/ctxKey.go
@@ -1,0 +1,10 @@
+package contextKey
+
+type userIDKey struct {}
+var UserIDKey = userIDKey{}
+
+type idpKey struct {}
+var IDPKey = idpKey{}
+
+type keywordKey struct {}
+var KeywordKey = keywordKey{}

--- a/app/internal/handler/company_handler.go
+++ b/app/internal/handler/company_handler.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/labstack/echo/v4"
 
-	"es-api/app/internal/usecase"
 	"es-api/app/internal/contextKey"
+	"es-api/app/internal/usecase"
 )
 
 type CompanyHandler interface {

--- a/app/internal/handler/company_handler.go
+++ b/app/internal/handler/company_handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"es-api/app/internal/usecase"
+	"es-api/app/internal/contextKey"
 )
 
 type CompanyHandler interface {
@@ -33,7 +34,7 @@ func (h *companyHandler) SearchCompanies(c echo.Context) error {
 	}
 
 	ctx := c.Request().Context()
-	ctx = context.WithValue(ctx, "keyword", keyword)
+	ctx = context.WithValue(ctx, contextKey.KeywordKey, keyword)
 	companies, err := h.companyUsecase.SearchCompanies(ctx, keyword)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{

--- a/app/internal/handler/company_handler.go
+++ b/app/internal/handler/company_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -31,7 +32,9 @@ func (h *companyHandler) SearchCompanies(c echo.Context) error {
 		})
 	}
 
-	companies, err := h.companyUsecase.SearchCompanies(c, keyword)
+	ctx := c.Request().Context()
+	ctx = context.WithValue(ctx, "keyword", keyword)
+	companies, err := h.companyUsecase.SearchCompanies(ctx, keyword)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": fmt.Sprintf("failed to search companies: %v", err),

--- a/app/internal/handler/company_handler_test.go
+++ b/app/internal/handler/company_handler_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -18,7 +19,7 @@ type mockCompanyUsecase struct {
 	testifymock.Mock
 }
 
-func (m *mockCompanyUsecase) SearchCompanies(ctx echo.Context, keyword string) ([]model.CompanyBasicInfo, error) {
+func (m *mockCompanyUsecase) SearchCompanies(ctx context.Context, keyword string) ([]model.CompanyBasicInfo, error) {
 	args := m.Called(ctx, keyword)
 	return args.Get(0).([]model.CompanyBasicInfo), args.Error(1)
 }

--- a/app/internal/handler/experience_handler.go
+++ b/app/internal/handler/experience_handler.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	"es-api/app/internal/contextKey"
 	"es-api/app/internal/entity/model"
 	"es-api/app/internal/usecase"
-	"es-api/app/internal/contextKey"
 )
 
 type ExperienceHandler interface {

--- a/app/internal/handler/experience_handler.go
+++ b/app/internal/handler/experience_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"es-api/app/internal/entity/model"
 	"es-api/app/internal/usecase"
+	"es-api/app/internal/contextKey"
 )
 
 type ExperienceHandler interface {
@@ -27,8 +28,8 @@ func (h *experienceHandler) GetExperienceByUserID(c echo.Context) error {
 	ctx := c.Request().Context()
 	idp := c.Request().Header.Get("idp")
 	userID := c.Get("userID")
-	ctx = context.WithValue(ctx, "idp", idp)
-	ctx = context.WithValue(ctx, "userID", userID)
+	ctx = context.WithValue(ctx, contextKey.IDPKey, idp)
+	ctx = context.WithValue(ctx, contextKey.UserIDKey, userID)
 	experience, err := h.eu.GetExperienceByUserID(ctx)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
@@ -44,8 +45,8 @@ func (h *experienceHandler) PostExperience(c echo.Context) error {
 	ctx := c.Request().Context()
 	idp := c.Request().Header.Get("idp")
 	userID := c.Get("userID")
-	ctx = context.WithValue(ctx, "idp", idp)
-	ctx = context.WithValue(ctx, "userID", userID)
+	ctx = context.WithValue(ctx, contextKey.IDPKey, idp)
+	ctx = context.WithValue(ctx, contextKey.UserIDKey, userID)
 	experience, err := h.eu.PostExperience(ctx, inputExperience)
 
 	if err != nil {

--- a/app/internal/handler/experience_handler.go
+++ b/app/internal/handler/experience_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -23,7 +24,12 @@ func NewExperienceHandler(eu usecase.ExperienceUsecase) ExperienceHandler {
 }
 
 func (h *experienceHandler) GetExperienceByUserID(c echo.Context) error {
-	experience, err := h.eu.GetExperienceByUserID(c)
+	ctx := c.Request().Context()
+	idp := c.Request().Header.Get("idp")
+	userID := c.Get("userID")
+	ctx = context.WithValue(ctx, "idp", idp)
+	ctx = context.WithValue(ctx, "userID", userID)
+	experience, err := h.eu.GetExperienceByUserID(ctx)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
@@ -35,7 +41,12 @@ func (h *experienceHandler) PostExperience(c echo.Context) error {
 	if err := c.Bind(&inputExperience); err != nil {
 		return c.JSON(http.StatusBadRequest, err.Error())
 	}
-	experience, err := h.eu.PostExperience(c, inputExperience)
+	ctx := c.Request().Context()
+	idp := c.Request().Header.Get("idp")
+	userID := c.Get("userID")
+	ctx = context.WithValue(ctx, "idp", idp)
+	ctx = context.WithValue(ctx, "userID", userID)
+	experience, err := h.eu.PostExperience(ctx, inputExperience)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, err.Error())

--- a/app/internal/handler/experience_handler_test.go
+++ b/app/internal/handler/experience_handler_test.go
@@ -37,8 +37,10 @@ func TestExperienceHandler_GetExperienceByUserID(t *testing.T) {
 
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/api/experience", nil)
+		req.Header.Set("idp", "test-idp")
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
+		c.Set("userID", "test-user-id")
 
 		err := h.GetExperienceByUserID(c)
 		assert.NoError(t, err)
@@ -81,8 +83,10 @@ func TestExperienceHandler_PostExperience(t *testing.T) {
 		reqBody, _ := json.Marshal(inputExperience)
 		req := httptest.NewRequest(http.MethodPost, "/api/experience", bytes.NewBuffer(reqBody))
 		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		req.Header.Set("idp", "test-idp")
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
+		c.Set("userID", "test-user-id")
 
 		err := h.PostExperience(c)
 		assert.NoError(t, err)

--- a/app/internal/handler/llm_generate_handler.go
+++ b/app/internal/handler/llm_generate_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"log"
 	"net/http"
 
@@ -41,7 +42,13 @@ func (h *llmGenerateHandler) Generate(c echo.Context) error {
 		})
 	}
 
-	result, err := h.llmenerateUsecase.LLMGenerate(c, *req)
+	ctx := c.Request().Context()
+	idp := c.Request().Header.Get("idp")
+	userID := c.Get("userID")
+	ctx = context.WithValue(ctx, "idp", idp)
+	ctx = context.WithValue(ctx, "userID", userID)
+
+	result, err := h.llmenerateUsecase.LLMGenerate(ctx, *req)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{

--- a/app/internal/handler/llm_generate_handler.go
+++ b/app/internal/handler/llm_generate_handler.go
@@ -9,6 +9,8 @@ import (
 	"es-api/app/internal/usecase"
 
 	"github.com/labstack/echo/v4"
+
+	"es-api/app/internal/contextKey"
 )
 
 type LLMGenerateHandler interface {
@@ -45,8 +47,8 @@ func (h *llmGenerateHandler) Generate(c echo.Context) error {
 	ctx := c.Request().Context()
 	idp := c.Request().Header.Get("idp")
 	userID := c.Get("userID")
-	ctx = context.WithValue(ctx, "idp", idp)
-	ctx = context.WithValue(ctx, "userID", userID)
+	ctx = context.WithValue(ctx, contextKey.IDPKey, idp)
+	ctx = context.WithValue(ctx, contextKey.UserIDKey, userID)
 
 	result, err := h.llmenerateUsecase.LLMGenerate(ctx, *req)
 

--- a/app/internal/repository/db/company_research_repository.go
+++ b/app/internal/repository/db/company_research_repository.go
@@ -5,6 +5,7 @@ import (
 
 	"es-api/app/infrastructure/db"
 	"es-api/app/internal/entity/model"
+	"es-api/app/internal/contextKey"
 
 	"gorm.io/gorm"
 )
@@ -34,7 +35,7 @@ func NewCompanyResearchRepositoryWithDBManager(dbManager db.DBConnectionManager)
 
 // FindByCompanyID - 法人番号で企業情報を検索
 func (r *companyResearchRepository) FindByCompanyID(ctx context.Context, companyID string) (*model.CompanyResearch, error) {
-	idp := ctx.Value("idp").(string)
+	idp := ctx.Value(contextKey.IDPKey).(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)
@@ -55,7 +56,7 @@ func (r *companyResearchRepository) FindByCompanyID(ctx context.Context, company
 
 // Create - 企業情報を新規作成
 func (r *companyResearchRepository) Create(ctx context.Context, research *model.CompanyResearch) error {
-	idp := ctx.Value("idp").(string)
+	idp := ctx.Value(contextKey.IDPKey).(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)

--- a/app/internal/repository/db/company_research_repository.go
+++ b/app/internal/repository/db/company_research_repository.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"es-api/app/infrastructure/db"
-	"es-api/app/internal/entity/model"
 	"es-api/app/internal/contextKey"
+	"es-api/app/internal/entity/model"
 
 	"gorm.io/gorm"
 )

--- a/app/internal/repository/db/company_research_repository.go
+++ b/app/internal/repository/db/company_research_repository.go
@@ -1,16 +1,17 @@
 package repository
 
 import (
+	"context"
+
 	"es-api/app/infrastructure/db"
 	"es-api/app/internal/entity/model"
 
-	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
 
 type CompanyResearchRepository interface {
-	FindByCompanyID(c echo.Context, companyID string) (*model.CompanyResearch, error)
-	Create(c echo.Context, research *model.CompanyResearch) error
+	FindByCompanyID(ctx context.Context, companyID string) (*model.CompanyResearch, error)
+	Create(ctx context.Context, research *model.CompanyResearch) error
 }
 
 type companyResearchRepository struct {
@@ -32,8 +33,8 @@ func NewCompanyResearchRepositoryWithDBManager(dbManager db.DBConnectionManager)
 }
 
 // FindByCompanyID - 法人番号で企業情報を検索
-func (r *companyResearchRepository) FindByCompanyID(c echo.Context, companyID string) (*model.CompanyResearch, error) {
-	idp := c.Request().Header.Get("idp")
+func (r *companyResearchRepository) FindByCompanyID(ctx context.Context, companyID string) (*model.CompanyResearch, error) {
+	idp := ctx.Value("idp").(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)
@@ -53,8 +54,8 @@ func (r *companyResearchRepository) FindByCompanyID(c echo.Context, companyID st
 }
 
 // Create - 企業情報を新規作成
-func (r *companyResearchRepository) Create(c echo.Context, research *model.CompanyResearch) error {
-	idp := c.Request().Header.Get("idp")
+func (r *companyResearchRepository) Create(ctx context.Context, research *model.CompanyResearch) error {
+	idp := ctx.Value("idp").(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)

--- a/app/internal/repository/db/company_research_repository_test.go
+++ b/app/internal/repository/db/company_research_repository_test.go
@@ -1,7 +1,6 @@
 package repository_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,7 +18,7 @@ func TestCompanyResearchRepository_FindByCompanyID(t *testing.T) {
 	repo := repository.NewCompanyResearchRepository(db)
 
 	t.Run("異常系:企業情報が存在しない場合", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := test.SetupContextContext("test-user-id")
 		research, err := repo.FindByCompanyID(ctx, "non-existent-id")
 
 		assert.NoError(t, err)
@@ -29,7 +28,8 @@ func TestCompanyResearchRepository_FindByCompanyID(t *testing.T) {
 	t.Run("正常系:企業情報が存在する場合", func(t *testing.T) {
 		dummyResearch := factory.CreateCompanyResearch(t, db)
 
-		ctx := context.Background()
+		// context.Background()ではなく、正しくセットアップされたコンテキストを使用
+		ctx := test.SetupContextContext("test-user-id")
 		research, err := repo.FindByCompanyID(ctx, dummyResearch.CompanyID)
 		assert.NoError(t, err)
 		assert.NotNil(t, research)
@@ -56,7 +56,7 @@ func TestCompanyResearchRepository_Create(t *testing.T) {
 			TalentNeeds: "テスト求める人材像2",
 		}
 
-		ctx := context.Background()
+		ctx := test.SetupContextContext("test-user-id")
 		err := repo.Create(ctx, newResearch)
 
 		assert.NoError(t, err)

--- a/app/internal/repository/db/company_research_repository_test.go
+++ b/app/internal/repository/db/company_research_repository_test.go
@@ -1,6 +1,7 @@
 package repository_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func TestCompanyResearchRepository_FindByCompanyID(t *testing.T) {
 	repo := repository.NewCompanyResearchRepository(db)
 
 	t.Run("異常系:企業情報が存在しない場合", func(t *testing.T) {
-		ctx := test.SetupEchoContext("")
+		ctx := context.Background()
 		research, err := repo.FindByCompanyID(ctx, "non-existent-id")
 
 		assert.NoError(t, err)
@@ -28,7 +29,7 @@ func TestCompanyResearchRepository_FindByCompanyID(t *testing.T) {
 	t.Run("正常系:企業情報が存在する場合", func(t *testing.T) {
 		dummyResearch := factory.CreateCompanyResearch(t, db)
 
-		ctx := test.SetupEchoContext("")
+		ctx := context.Background()
 		research, err := repo.FindByCompanyID(ctx, dummyResearch.CompanyID)
 		assert.NoError(t, err)
 		assert.NotNil(t, research)
@@ -55,7 +56,7 @@ func TestCompanyResearchRepository_Create(t *testing.T) {
 			TalentNeeds: "テスト求める人材像2",
 		}
 
-		ctx := test.SetupEchoContext("")
+		ctx := context.Background()
 		err := repo.Create(ctx, newResearch)
 
 		assert.NoError(t, err)

--- a/app/internal/repository/db/experience_repository.go
+++ b/app/internal/repository/db/experience_repository.go
@@ -1,9 +1,9 @@
 package repository
 
 import (
+	"context"
 	"errors"
 
-	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 
 	"es-api/app/infrastructure/db"
@@ -11,10 +11,10 @@ import (
 )
 
 type ExperienceRepository interface {
-	GetExperienceByUserID(c echo.Context) (model.Experiences, error)
-	FindExperienceByUserID(c echo.Context) (bool, error)
-	PostExperience(c echo.Context, input model.InputExperience) (model.Experiences, error)
-	PatchExperience(c echo.Context, input model.InputExperience) (model.Experiences, error)
+	GetExperienceByUserID(ctx context.Context) (model.Experiences, error)
+	FindExperienceByUserID(ctx context.Context) (bool, error)
+	PostExperience(ctx context.Context, input model.InputExperience) (model.Experiences, error)
+	PatchExperience(ctx context.Context, input model.InputExperience) (model.Experiences, error)
 }
 
 type experienceRepository struct {
@@ -35,10 +35,10 @@ func NewExperienceRepositoryWithDBManager(dbManager db.DBConnectionManager) Expe
 	}
 }
 
-func (r *experienceRepository) GetExperienceByUserID(c echo.Context) (model.Experiences, error) {
+func (r *experienceRepository) GetExperienceByUserID(ctx context.Context) (model.Experiences, error) {
 	var experience model.Experiences
-	idp := c.Request().Header.Get("idp")
-	userID := c.Get("userID")
+	idp := ctx.Value("idp").(string)
+	userID := ctx.Value("userID").(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)
@@ -52,10 +52,10 @@ func (r *experienceRepository) GetExperienceByUserID(c echo.Context) (model.Expe
 	return experience, nil
 }
 
-func (r *experienceRepository) FindExperienceByUserID(c echo.Context) (bool, error) {
+func (r *experienceRepository) FindExperienceByUserID(ctx context.Context) (bool, error) {
 	var experience model.Experiences
-	idp := c.Request().Header.Get("idp")
-	userID := c.Get("userID")
+	idp := ctx.Value("idp").(string)
+	userID := ctx.Value("userID").(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)
@@ -72,9 +72,9 @@ func (r *experienceRepository) FindExperienceByUserID(c echo.Context) (bool, err
 	return true, nil
 }
 
-func (r *experienceRepository) PostExperience(c echo.Context, input model.InputExperience) (model.Experiences, error) {
-	idp := c.Request().Header.Get("idp")
-	userID := c.Get("userID").(string)
+func (r *experienceRepository) PostExperience(ctx context.Context, input model.InputExperience) (model.Experiences, error) {
+	idp := ctx.Value("idp").(string)
+	userID := ctx.Value("userID").(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)
@@ -96,9 +96,9 @@ func (r *experienceRepository) PostExperience(c echo.Context, input model.InputE
 	return experience, nil
 }
 
-func (r *experienceRepository) PatchExperience(c echo.Context, input model.InputExperience) (model.Experiences, error) {
-	idp := c.Request().Header.Get("idp")
-	userID := c.Get("userID").(string)
+func (r *experienceRepository) PatchExperience(ctx context.Context, input model.InputExperience) (model.Experiences, error) {
+	idp := ctx.Value("idp").(string)
+	userID := ctx.Value("userID").(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)

--- a/app/internal/repository/db/experience_repository.go
+++ b/app/internal/repository/db/experience_repository.go
@@ -8,6 +8,7 @@ import (
 
 	"es-api/app/infrastructure/db"
 	"es-api/app/internal/entity/model"
+	"es-api/app/internal/contextKey"
 )
 
 type ExperienceRepository interface {
@@ -37,8 +38,8 @@ func NewExperienceRepositoryWithDBManager(dbManager db.DBConnectionManager) Expe
 
 func (r *experienceRepository) GetExperienceByUserID(ctx context.Context) (model.Experiences, error) {
 	var experience model.Experiences
-	idp := ctx.Value("idp").(string)
-	userID := ctx.Value("userID").(string)
+	idp := ctx.Value(contextKey.IDPKey).(string)
+	userID := ctx.Value(contextKey.UserIDKey).(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)
@@ -54,8 +55,8 @@ func (r *experienceRepository) GetExperienceByUserID(ctx context.Context) (model
 
 func (r *experienceRepository) FindExperienceByUserID(ctx context.Context) (bool, error) {
 	var experience model.Experiences
-	idp := ctx.Value("idp").(string)
-	userID := ctx.Value("userID").(string)
+	idp := ctx.Value(contextKey.IDPKey).(string)
+	userID := ctx.Value(contextKey.UserIDKey).(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)
@@ -73,8 +74,8 @@ func (r *experienceRepository) FindExperienceByUserID(ctx context.Context) (bool
 }
 
 func (r *experienceRepository) PostExperience(ctx context.Context, input model.InputExperience) (model.Experiences, error) {
-	idp := ctx.Value("idp").(string)
-	userID := ctx.Value("userID").(string)
+	idp := ctx.Value(contextKey.IDPKey).(string)
+	userID := ctx.Value(contextKey.UserIDKey).(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)
@@ -97,8 +98,8 @@ func (r *experienceRepository) PostExperience(ctx context.Context, input model.I
 }
 
 func (r *experienceRepository) PatchExperience(ctx context.Context, input model.InputExperience) (model.Experiences, error) {
-	idp := ctx.Value("idp").(string)
-	userID := ctx.Value("userID").(string)
+	idp := ctx.Value(contextKey.IDPKey).(string)
+	userID := ctx.Value(contextKey.UserIDKey).(string)
 	var dbConn *gorm.DB
 	if r.dbManager != nil && idp != "" {
 		dbConn = r.dbManager.GetConnection(idp)

--- a/app/internal/repository/db/experience_repository.go
+++ b/app/internal/repository/db/experience_repository.go
@@ -7,8 +7,8 @@ import (
 	"gorm.io/gorm"
 
 	"es-api/app/infrastructure/db"
-	"es-api/app/internal/entity/model"
 	"es-api/app/internal/contextKey"
+	"es-api/app/internal/entity/model"
 )
 
 type ExperienceRepository interface {

--- a/app/internal/repository/db/experience_repository_test.go
+++ b/app/internal/repository/db/experience_repository_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"es-api/app/internal/entity/model"
 	"es-api/app/internal/contextKey"
+	"es-api/app/internal/entity/model"
 	repository "es-api/app/internal/repository/db"
 	"es-api/app/test"
 	"es-api/app/test/factory"

--- a/app/internal/repository/db/experience_repository_test.go
+++ b/app/internal/repository/db/experience_repository_test.go
@@ -1,6 +1,7 @@
 package repository_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +21,8 @@ func TestExperienceRepository_GetExperienceByUserID(t *testing.T) {
 	t.Run("異常系:ユーザーが存在しない場合", func(t *testing.T) {
 		_ = factory.CreateUser2(t, db)
 
-		ctx := test.SetupEchoContext(factory.DummyUserID1)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, "userID", factory.DummyUserID1)
 		experience, err := repo.GetExperienceByUserID(ctx)
 
 		assert.Error(t, err)
@@ -31,7 +33,8 @@ func TestExperienceRepository_GetExperienceByUserID(t *testing.T) {
 		dummyUser := factory.CreateUser1(t, db)
 		dummyExperience := factory.CreateExperience1(t, db)
 
-		ctx := test.SetupEchoContext(dummyUser.ID)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
 		res, err := repo.GetExperienceByUserID(ctx)
 
 		assert.NoError(t, err)
@@ -47,7 +50,8 @@ func TestExperienceRepository_FindExperienceByUserID(t *testing.T) {
 	dummyUser := factory.CreateUser1(t, db)
 
 	t.Run("異常系:経験が存在しない場合", func(t *testing.T) {
-		ctx := test.SetupEchoContext(dummyUser.ID)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
 		res, err := repo.FindExperienceByUserID(ctx)
 
 		assert.NoError(t, err)
@@ -57,7 +61,8 @@ func TestExperienceRepository_FindExperienceByUserID(t *testing.T) {
 	t.Run("正常系:経験が存在する場合", func(t *testing.T) {
 		_ = factory.CreateExperience1(t, db)
 
-		ctx := test.SetupEchoContext(dummyUser.ID)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
 		res, err := repo.FindExperienceByUserID(ctx)
 
 		assert.NoError(t, err)
@@ -80,7 +85,8 @@ func TestExperienceRepository_PostExperience(t *testing.T) {
 			FutureGoals: "test-future-goals",
 		}
 
-		ctx := test.SetupEchoContext(dummyUser.ID)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
 		experience, err := repo.PostExperience(ctx, input)
 
 		assert.NoError(t, err)
@@ -108,7 +114,8 @@ func TestExperienceRepository_PatchExperience(t *testing.T) {
 			FutureGoals: "updated-future-goals",
 		}
 
-		ctx := test.SetupEchoContext(dummyUser.ID)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
 		experience, err := repo.PatchExperience(ctx, input)
 
 		assert.NoError(t, err)

--- a/app/internal/repository/db/experience_repository_test.go
+++ b/app/internal/repository/db/experience_repository_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"es-api/app/internal/entity/model"
+	"es-api/app/internal/contextKey"
 	repository "es-api/app/internal/repository/db"
 	"es-api/app/test"
 	"es-api/app/test/factory"
@@ -22,7 +23,7 @@ func TestExperienceRepository_GetExperienceByUserID(t *testing.T) {
 		_ = factory.CreateUser2(t, db)
 
 		ctx := test.SetupContextContext("test-user-id")
-		ctx = context.WithValue(ctx, "userID", factory.DummyUserID1)
+		ctx = context.WithValue(ctx, contextKey.userIDKey, factory.DummyUserID1)
 		experience, err := repo.GetExperienceByUserID(ctx)
 
 		assert.Error(t, err)
@@ -34,7 +35,7 @@ func TestExperienceRepository_GetExperienceByUserID(t *testing.T) {
 		dummyExperience := factory.CreateExperience1(t, db)
 
 		ctx := test.SetupContextContext("test-user-id")
-		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
+		ctx = context.WithValue(ctx, contextKey.UserIDKey, dummyUser.ID)
 		res, err := repo.GetExperienceByUserID(ctx)
 
 		assert.NoError(t, err)
@@ -51,7 +52,7 @@ func TestExperienceRepository_FindExperienceByUserID(t *testing.T) {
 
 	t.Run("異常系:経験が存在しない場合", func(t *testing.T) {
 		ctx := test.SetupContextContext("test-user-id")
-		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
+		ctx = context.WithValue(ctx, contextKey.UserIDKey, dummyUser.ID)
 		res, err := repo.FindExperienceByUserID(ctx)
 
 		assert.NoError(t, err)
@@ -62,7 +63,7 @@ func TestExperienceRepository_FindExperienceByUserID(t *testing.T) {
 		_ = factory.CreateExperience1(t, db)
 
 		ctx := test.SetupContextContext("test-user-id")
-		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
+		ctx = context.WithValue(ctx, contextKey.UserIDKey, dummyUser.ID)
 		res, err := repo.FindExperienceByUserID(ctx)
 
 		assert.NoError(t, err)
@@ -86,7 +87,7 @@ func TestExperienceRepository_PostExperience(t *testing.T) {
 		}
 
 		ctx := test.SetupContextContext("test-user-id")
-		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
+		ctx = context.WithValue(ctx, contextKey.UserIDKey, dummyUser.ID)
 		experience, err := repo.PostExperience(ctx, input)
 
 		assert.NoError(t, err)
@@ -115,7 +116,7 @@ func TestExperienceRepository_PatchExperience(t *testing.T) {
 		}
 
 		ctx := test.SetupContextContext("test-user-id")
-		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
+		ctx = context.WithValue(ctx, contextKey.UserIDKey, dummyUser.ID)
 		experience, err := repo.PatchExperience(ctx, input)
 
 		assert.NoError(t, err)

--- a/app/internal/repository/db/experience_repository_test.go
+++ b/app/internal/repository/db/experience_repository_test.go
@@ -23,7 +23,7 @@ func TestExperienceRepository_GetExperienceByUserID(t *testing.T) {
 		_ = factory.CreateUser2(t, db)
 
 		ctx := test.SetupContextContext("test-user-id")
-		ctx = context.WithValue(ctx, contextKey.userIDKey, factory.DummyUserID1)
+		ctx = context.WithValue(ctx, contextKey.UserIDKey, factory.DummyUserID1)
 		experience, err := repo.GetExperienceByUserID(ctx)
 
 		assert.Error(t, err)

--- a/app/internal/repository/db/experience_repository_test.go
+++ b/app/internal/repository/db/experience_repository_test.go
@@ -21,7 +21,7 @@ func TestExperienceRepository_GetExperienceByUserID(t *testing.T) {
 	t.Run("異常系:ユーザーが存在しない場合", func(t *testing.T) {
 		_ = factory.CreateUser2(t, db)
 
-		ctx := context.Background()
+		ctx := test.SetupContextContext("test-user-id")
 		ctx = context.WithValue(ctx, "userID", factory.DummyUserID1)
 		experience, err := repo.GetExperienceByUserID(ctx)
 
@@ -33,7 +33,7 @@ func TestExperienceRepository_GetExperienceByUserID(t *testing.T) {
 		dummyUser := factory.CreateUser1(t, db)
 		dummyExperience := factory.CreateExperience1(t, db)
 
-		ctx := context.Background()
+		ctx := test.SetupContextContext("test-user-id")
 		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
 		res, err := repo.GetExperienceByUserID(ctx)
 
@@ -50,7 +50,7 @@ func TestExperienceRepository_FindExperienceByUserID(t *testing.T) {
 	dummyUser := factory.CreateUser1(t, db)
 
 	t.Run("異常系:経験が存在しない場合", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := test.SetupContextContext("test-user-id")
 		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
 		res, err := repo.FindExperienceByUserID(ctx)
 
@@ -61,7 +61,7 @@ func TestExperienceRepository_FindExperienceByUserID(t *testing.T) {
 	t.Run("正常系:経験が存在する場合", func(t *testing.T) {
 		_ = factory.CreateExperience1(t, db)
 
-		ctx := context.Background()
+		ctx := test.SetupContextContext("test-user-id")
 		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
 		res, err := repo.FindExperienceByUserID(ctx)
 
@@ -85,7 +85,7 @@ func TestExperienceRepository_PostExperience(t *testing.T) {
 			FutureGoals: "test-future-goals",
 		}
 
-		ctx := context.Background()
+		ctx := test.SetupContextContext("test-user-id")
 		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
 		experience, err := repo.PostExperience(ctx, input)
 
@@ -114,7 +114,7 @@ func TestExperienceRepository_PatchExperience(t *testing.T) {
 			FutureGoals: "updated-future-goals",
 		}
 
-		ctx := context.Background()
+		ctx := test.SetupContextContext("test-user-id")
 		ctx = context.WithValue(ctx, "userID", dummyUser.ID)
 		experience, err := repo.PatchExperience(ctx, input)
 

--- a/app/internal/repository/gbiz/gbiz_repository.go
+++ b/app/internal/repository/gbiz/gbiz_repository.go
@@ -1,6 +1,7 @@
 package gbiz
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -8,12 +9,10 @@ import (
 	"os"
 
 	"es-api/app/internal/entity/model"
-
-	"github.com/labstack/echo/v4"
 )
 
 type GBizInfoRepository interface {
-	SearchCompanies(c echo.Context, keyword string) ([]model.CompanyBasicInfo, error)
+	SearchCompanies(ctx context.Context, keyword string) ([]model.CompanyBasicInfo, error)
 }
 
 type gbizInfoRepository struct {
@@ -27,7 +26,7 @@ func NewGBizInfoRepository() GBizInfoRepository {
 }
 
 // SearchCompanies - 法人名の検索を行う
-func (r *gbizInfoRepository) SearchCompanies(c echo.Context, keyword string) ([]model.CompanyBasicInfo, error) {
+func (r *gbizInfoRepository) SearchCompanies(ctx context.Context, keyword string) ([]model.CompanyBasicInfo, error) {
 	apiKey := os.Getenv("GBIZ_API_KEY")
 	if apiKey == "" {
 		return nil, fmt.Errorf("GBIZ_API_KEY is not set")

--- a/app/internal/repository/gbiz/gbiz_repository_test.go
+++ b/app/internal/repository/gbiz/gbiz_repository_test.go
@@ -18,7 +18,7 @@ func TestGBizInfoRepository(t *testing.T) {
 				// 環境変数のセットアップ
 				t.Setenv("GBIZ_API_KEY", "dummy-api-key")
 
-				ctx := test.SetupEchoContext("")
+				ctx := test.SetupContextContext("")
 				keyword := "テスト株式会社"
 				expected := []model.CompanyBasicInfo{
 					{
@@ -43,7 +43,7 @@ func TestGBizInfoRepository(t *testing.T) {
 				// 環境変数のセットアップ
 				t.Setenv("GBIZ_API_KEY", "")
 
-				ctx := test.SetupEchoContext("")
+				ctx := test.SetupContextContext("")
 				keyword := "テスト株式会社"
 
 				// モックを使用したテスト
@@ -60,7 +60,7 @@ func TestGBizInfoRepository(t *testing.T) {
 				// 環境変数のセットアップ
 				t.Setenv("GBIZ_API_KEY", "dummy-api-key")
 
-				ctx := test.SetupEchoContext("")
+				ctx := test.SetupContextContext("")
 				keyword := "テスト株式会社"
 
 				// モックを使用したテスト

--- a/app/internal/repository/gemini/gemini_repository.go
+++ b/app/internal/repository/gemini/gemini_repository.go
@@ -1,18 +1,18 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"es-api/app/internal/entity/model"
 
 	"github.com/google/generative-ai-go/genai"
-	"github.com/labstack/echo/v4"
 	"google.golang.org/api/option"
 )
 
 type GeminiRepository interface {
-	GetGeminiRequest(c echo.Context, input model.GeminiInput) (model.GeminiResponse, error)
+	GetGeminiRequest(ctx context.Context, input model.GeminiInput) (model.GeminiResponse, error)
 }
 
 type geminiRepository struct{}
@@ -21,8 +21,8 @@ func NewGeminiRepository() GeminiRepository {
 	return &geminiRepository{}
 }
 
-func (r *geminiRepository) GetGeminiRequest(c echo.Context, input model.GeminiInput) (model.GeminiResponse, error) {
-	client, err := genai.NewClient(c.Request().Context(), option.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
+func (r *geminiRepository) GetGeminiRequest(ctx context.Context, input model.GeminiInput) (model.GeminiResponse, error) {
+	client, err := genai.NewClient(ctx, option.WithAPIKey(os.Getenv("GEMINI_API_KEY")))
 	if err != nil {
 		return model.GeminiResponse{}, err
 	}
@@ -31,7 +31,7 @@ func (r *geminiRepository) GetGeminiRequest(c echo.Context, input model.GeminiIn
 	gemModel := client.GenerativeModel(string(input.Model))
 	text := input.Text
 
-	response, err := gemModel.GenerateContent(c.Request().Context(), genai.Text(text))
+	response, err := gemModel.GenerateContent(ctx, genai.Text(text))
 	if err != nil {
 		return model.GeminiResponse{}, err
 	}

--- a/app/internal/repository/gemini/gemini_repository_test.go
+++ b/app/internal/repository/gemini/gemini_repository_test.go
@@ -29,7 +29,7 @@ func TestGeminiRepository_GetGeminiRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := test.SetupEchoContext("")
+			ctx := test.SetupContextContext("")
 
 			// モックを使用したテスト
 			mockRepo := new(mock.GeminiRepositoryMock)

--- a/app/internal/usecase/company_usecase.go
+++ b/app/internal/usecase/company_usecase.go
@@ -1,14 +1,14 @@
 package usecase
 
 import (
+	"context"
+
 	"es-api/app/internal/entity/model"
 	"es-api/app/internal/repository/gbiz"
-
-	"github.com/labstack/echo/v4"
 )
 
 type CompanyUsecase interface {
-	SearchCompanies(c echo.Context, keyword string) ([]model.CompanyBasicInfo, error)
+	SearchCompanies(ctx context.Context, keyword string) ([]model.CompanyBasicInfo, error)
 }
 
 type companyUsecase struct {
@@ -21,6 +21,6 @@ func NewCompanyUsecase(gbizRepo gbiz.GBizInfoRepository) CompanyUsecase {
 	}
 }
 
-func (u *companyUsecase) SearchCompanies(c echo.Context, keyword string) ([]model.CompanyBasicInfo, error) {
-	return u.gbizRepo.SearchCompanies(c, keyword)
+func (u *companyUsecase) SearchCompanies(ctx context.Context, keyword string) ([]model.CompanyBasicInfo, error) {
+	return u.gbizRepo.SearchCompanies(ctx, keyword)
 }

--- a/app/internal/usecase/company_usecase_test.go
+++ b/app/internal/usecase/company_usecase_test.go
@@ -1,10 +1,10 @@
 package usecase_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	testifymock "github.com/stretchr/testify/mock"
 
@@ -24,8 +24,7 @@ func TestCompanyUsecase_SearchCompanies(t *testing.T) {
 			},
 		}
 
-		e := echo.New()
-		ctx := e.NewContext(nil, nil)
+		ctx := context.Background()
 		keyword := "株式会社テスト"
 
 		mockRepo.On("SearchCompanies", testifymock.Anything, keyword).Return(expectedCompanies, nil)
@@ -43,9 +42,7 @@ func TestCompanyUsecase_SearchCompanies(t *testing.T) {
 
 	t.Run("正常系:検索結果が空の場合", func(t *testing.T) {
 		mockRepo := new(mock.GBizInfoRepositoryMock)
-
-		e := echo.New()
-		ctx := e.NewContext(nil, nil)
+		ctx := context.Background()
 		keyword := "存在しない会社"
 
 		mockRepo.On("SearchCompanies", testifymock.Anything, keyword).Return([]model.CompanyBasicInfo{}, nil)
@@ -62,8 +59,7 @@ func TestCompanyUsecase_SearchCompanies(t *testing.T) {
 	t.Run("異常系:リポジトリでエラーが発生した場合", func(t *testing.T) {
 		mockRepo := new(mock.GBizInfoRepositoryMock)
 
-		e := echo.New()
-		ctx := e.NewContext(nil, nil)
+		ctx := context.Background()
 		keyword := "エラーケース"
 		expectedErr := errors.New("repository error")
 

--- a/app/internal/usecase/experience_usecase.go
+++ b/app/internal/usecase/experience_usecase.go
@@ -1,17 +1,16 @@
 package usecase
 
 import (
+	"context"
 	"fmt"
-
-	"github.com/labstack/echo/v4"
 
 	"es-api/app/internal/entity/model"
 	repository "es-api/app/internal/repository/db"
 )
 
 type ExperienceUsecase interface {
-	GetExperienceByUserID(c echo.Context) (*model.Experiences, error)
-	PostExperience(c echo.Context, experience model.InputExperience) (*model.Experiences, error)
+	GetExperienceByUserID(ctx context.Context) (*model.Experiences, error)
+	PostExperience(ctx context.Context, experience model.InputExperience) (*model.Experiences, error)
 }
 
 type experienceUsecase struct {
@@ -22,8 +21,8 @@ func NewExperienceUsecase(r repository.ExperienceRepository) ExperienceUsecase {
 	return &experienceUsecase{er: r}
 }
 
-func (u *experienceUsecase) GetExperienceByUserID(c echo.Context) (*model.Experiences, error) {
-	experience, err := u.er.GetExperienceByUserID(c)
+func (u *experienceUsecase) GetExperienceByUserID(ctx context.Context) (*model.Experiences, error) {
+	experience, err := u.er.GetExperienceByUserID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -31,14 +30,14 @@ func (u *experienceUsecase) GetExperienceByUserID(c echo.Context) (*model.Experi
 	return &experience, nil
 }
 
-func (u *experienceUsecase) PostExperience(c echo.Context, experience model.InputExperience) (*model.Experiences, error) {
-	exists, err := u.er.FindExperienceByUserID(c)
+func (u *experienceUsecase) PostExperience(ctx context.Context, experience model.InputExperience) (*model.Experiences, error) {
+	exists, err := u.er.FindExperienceByUserID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find experience by user ID: %w", err)
 	}
 
 	if exists {
-		experiences, err := u.er.PatchExperience(c, experience)
+		experiences, err := u.er.PatchExperience(ctx, experience)
 		if err != nil {
 			return nil, fmt.Errorf("failed to patch experience: %w", err)
 		}
@@ -46,7 +45,7 @@ func (u *experienceUsecase) PostExperience(c echo.Context, experience model.Inpu
 		return &experiences, nil
 	}
 
-	experiences, err := u.er.PostExperience(c, experience)
+	experiences, err := u.er.PostExperience(ctx, experience)
 	if err != nil {
 		return nil, fmt.Errorf("failed to post experience: %w", err)
 	}

--- a/app/internal/usecase/experience_usecase_test.go
+++ b/app/internal/usecase/experience_usecase_test.go
@@ -1,11 +1,11 @@
 package usecase_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	testifymock "github.com/stretchr/testify/mock"
 
@@ -24,8 +24,7 @@ func TestExperienceUsecase_GetExperienceByUserID(t *testing.T) {
 			UpdatedAt: time.Now(),
 		}
 
-		e := echo.New()
-		ctx := e.NewContext(nil, nil)
+		ctx := context.Background()
 		mockRepo.On("GetExperienceByUserID", testifymock.Anything).Return(experience, nil)
 
 		uc := usecase.NewExperienceUsecase(mockRepo)
@@ -41,8 +40,7 @@ func TestExperienceUsecase_GetExperienceByUserID(t *testing.T) {
 	t.Run("異常系:ユーザーが存在しない場合", func(t *testing.T) {
 		mockRepo := new(appmock.ExperienceRepositoryMock)
 
-		e := echo.New()
-		ctx := e.NewContext(nil, nil)
+		ctx := context.Background()
 		expectedErr := errors.New("repository error")
 		mockRepo.On("GetExperienceByUserID", testifymock.Anything).Return(model.Experiences{}, expectedErr)
 
@@ -79,8 +77,7 @@ func TestExperienceUsecase_PostExperience(t *testing.T) {
 			UpdatedAt:   time.Now(),
 		}
 
-		e := echo.New()
-		ctx := e.NewContext(nil, nil)
+		ctx := context.Background()
 		mockRepo.On("FindExperienceByUserID", testifymock.Anything).Return(false, nil)
 		mockRepo.On("PostExperience", testifymock.Anything, inputExperience).Return(createdExperience, nil)
 
@@ -119,8 +116,7 @@ func TestExperienceUsecase_PostExperience(t *testing.T) {
 			UpdatedAt:   time.Now(),
 		}
 
-		e := echo.New()
-		ctx := e.NewContext(nil, nil)
+		ctx := context.Background()
 		mockRepo.On("FindExperienceByUserID", testifymock.Anything).Return(true, nil)
 		mockRepo.On("PatchExperience", testifymock.Anything, inputExperience).Return(updatedExperience, nil)
 

--- a/app/test/helper.go
+++ b/app/test/helper.go
@@ -10,6 +10,7 @@ import (
 
 	"es-api/app/infrastructure/db"
 	"es-api/app/infrastructure/migrate"
+	"es-api/app/internal/contextKey"
 )
 
 func LoadEnvFile(t *testing.T, path string) {
@@ -39,7 +40,7 @@ func CleanupDB(t *testing.T, dbConn *gorm.DB) {
 
 func SetupContextContext(userID string) context.Context {
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, "userID", userID)
-	ctx = context.WithValue(ctx, "idp", "test")
+	ctx = context.WithValue(ctx, contextKey.UserIDKey, userID)
+	ctx = context.WithValue(ctx, contextKey.IDPKey, "test")
 	return ctx
 }

--- a/app/test/helper.go
+++ b/app/test/helper.go
@@ -1,13 +1,11 @@
 package test
 
 import (
+	"context"
 	"log"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/joho/godotenv"
-	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 
 	"es-api/app/infrastructure/db"
@@ -39,12 +37,9 @@ func CleanupDB(t *testing.T, dbConn *gorm.DB) {
 	sqlDB.Close()
 }
 
-func SetupEchoContext(userID string) echo.Context {
-	e := echo.New()
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	rec := httptest.NewRecorder()
-	req.Header.Set("idp", "test")
-	ctx := e.NewContext(req, rec)
-	ctx.Set("userID", userID)
+func SetupContextContext(userID string) context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, "userID", userID)
+	ctx = context.WithValue(ctx, "idp", "test")
 	return ctx
 }

--- a/app/test/mock/repository/experience_repository_mock.go
+++ b/app/test/mock/repository/experience_repository_mock.go
@@ -1,7 +1,8 @@
 package mock
 
 import (
-	"github.com/labstack/echo/v4"
+	"context"
+
 	"github.com/stretchr/testify/mock"
 
 	"es-api/app/internal/entity/model"
@@ -11,22 +12,22 @@ type ExperienceRepositoryMock struct {
 	mock.Mock
 }
 
-func (m *ExperienceRepositoryMock) GetExperienceByUserID(c echo.Context) (model.Experiences, error) {
-	args := m.Called(c)
+func (m *ExperienceRepositoryMock) GetExperienceByUserID(ctx context.Context) (model.Experiences, error) {
+	args := m.Called(ctx)
 	return args.Get(0).(model.Experiences), args.Error(1)
 }
 
-func (m *ExperienceRepositoryMock) FindExperienceByUserID(c echo.Context) (bool, error) {
-	args := m.Called(c)
+func (m *ExperienceRepositoryMock) FindExperienceByUserID(ctx context.Context) (bool, error) {
+	args := m.Called(ctx)
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *ExperienceRepositoryMock) PostExperience(c echo.Context, experience model.InputExperience) (model.Experiences, error) {
-	args := m.Called(c, experience)
+func (m *ExperienceRepositoryMock) PostExperience(ctx context.Context, experience model.InputExperience) (model.Experiences, error) {
+	args := m.Called(ctx, experience)
 	return args.Get(0).(model.Experiences), args.Error(1)
 }
 
-func (m *ExperienceRepositoryMock) PatchExperience(c echo.Context, experience model.InputExperience) (model.Experiences, error) {
-	args := m.Called(c, experience)
+func (m *ExperienceRepositoryMock) PatchExperience(ctx context.Context, experience model.InputExperience) (model.Experiences, error) {
+	args := m.Called(ctx, experience)
 	return args.Get(0).(model.Experiences), args.Error(1)
 }

--- a/app/test/mock/repository/gbiz_repository_mock.go
+++ b/app/test/mock/repository/gbiz_repository_mock.go
@@ -1,9 +1,10 @@
 package mock
 
 import (
+	"context"
+
 	"es-api/app/internal/entity/model"
 
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -11,8 +12,8 @@ type GBizInfoRepositoryMock struct {
 	mock.Mock
 }
 
-func (m *GBizInfoRepositoryMock) SearchCompanies(c echo.Context, keyword string) ([]model.CompanyBasicInfo, error) {
-	args := m.Called(c, keyword)
+func (m *GBizInfoRepositoryMock) SearchCompanies(ctx context.Context, keyword string) ([]model.CompanyBasicInfo, error) {
+	args := m.Called(ctx, keyword)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/app/test/mock/repository/gemini_repository_mock.go
+++ b/app/test/mock/repository/gemini_repository_mock.go
@@ -2,7 +2,7 @@ package mock
 
 import (
 	"context"
-	
+
 	"es-api/app/internal/entity/model"
 
 	"github.com/stretchr/testify/mock"

--- a/app/test/mock/repository/gemini_repository_mock.go
+++ b/app/test/mock/repository/gemini_repository_mock.go
@@ -1,9 +1,10 @@
 package mock
 
 import (
+	"context"
+	
 	"es-api/app/internal/entity/model"
 
-	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -11,7 +12,7 @@ type GeminiRepositoryMock struct {
 	mock.Mock
 }
 
-func (m *GeminiRepositoryMock) GetGeminiRequest(c echo.Context, input model.GeminiInput) (model.GeminiResponse, error) {
-	args := m.Called(c, input)
+func (m *GeminiRepositoryMock) GetGeminiRequest(ctx context.Context, input model.GeminiInput) (model.GeminiResponse, error) {
+	args := m.Called(ctx, input)
 	return args.Get(0).(model.GeminiResponse), args.Error(1)
 }

--- a/app/test/mock/usecase/experience_usecase_mock.go
+++ b/app/test/mock/usecase/experience_usecase_mock.go
@@ -1,18 +1,19 @@
 package mock
 
 import (
-	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/mock"
+	"context"
 
 	"es-api/app/internal/entity/model"
+
+	"github.com/stretchr/testify/mock"
 )
 
 type ExperienceUsecaseMock struct {
 	mock.Mock
 }
 
-func (m *ExperienceUsecaseMock) GetExperienceByUserID(c echo.Context) (*model.Experiences, error) {
-	args := m.Called(c)
+func (m *ExperienceUsecaseMock) GetExperienceByUserID(ctx context.Context) (*model.Experiences, error) {
+	args := m.Called(ctx)
 
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -21,8 +22,8 @@ func (m *ExperienceUsecaseMock) GetExperienceByUserID(c echo.Context) (*model.Ex
 	return args.Get(0).(*model.Experiences), args.Error(1)
 }
 
-func (m *ExperienceUsecaseMock) PostExperience(c echo.Context, inputExperience model.InputExperience) (*model.Experiences, error) {
-	args := m.Called(c, inputExperience)
+func (m *ExperienceUsecaseMock) PostExperience(ctx context.Context, inputExperience model.InputExperience) (*model.Experiences, error) {
+	args := m.Called(ctx, inputExperience)
 
 	if args.Get(0) == nil {
 		return nil, args.Error(1)


### PR DESCRIPTION
## 概要
- echo.Contextをhandlerでcontext.Contextに入れて、usecase層以降ではcontext.Contextを渡すようにする
<!-- Jiraのチケット、Issuesなどあれば記載 -->
<!-- PRの概要と実施背景を記載 -->

## 変更点
- echoで渡していたcontextを全て標準ライブラリのcontextにする
<!-- コードの変更点を明記 -->
<!-- 必要に応じてスクリーンショットやドキュメントなどのリンクを貼る -->

## 影響範囲・懸念点
- echoの受け渡しは多分ないはず（usecase以降）
- idpやuseIDは今までrepository層で取得していたのをhandlerで取得して、以降それをずっと引き継ぐようになってる（元からエラーハンドリングとかなかったからなんもしていない）
- timeoutなどはctxを拡張させる感じで出来るはず（usecaseで設定）
- handlerでechoからcontextに取り出している（handlerでいいんだよね、？）
- `context.WithValue() のキーとして string を直接使うべきではない`と怒られるかも？（warning)
  - stringだと異なるパッケージ内で同じ単語で使用された時に上書きされてしまい、意図しない挙動が起こるから
  - Goのベストプラクティスとしては独自の型を定義する方がいいらしい

未完成部分
- [x] テストの変更（モックなども）
- [x] 独自の型の定義（やっぱめんどくさいので一旦やめたい気持ち）
<!-- 影響が及びそうな範囲、レビューしてほしい点を記載 -->


## 動作確認
- swaggerで動作確認済み
<!-- 実施した動作確認 -->
<!-- レビュイーのために実際のコマンドなどあると◯ -->

## その他
#20 
コミットメッセージミスったけどpushしちゃってrebaseするのとかめんどくさいからこのままです